### PR TITLE
Add PDF Arranger to installed flatpaks

### DIFF
--- a/roles/workstation/tasks/flatpaks.yml
+++ b/roles/workstation/tasks/flatpaks.yml
@@ -26,6 +26,7 @@
     - org.videolan.VLC
     - org.telegram.desktop
     - org.libreoffice.LibreOffice
+    - com.github.jeromerobert.pdfarranger
 
 - name: Configure VS Code
   command: "{{ item }}"


### PR DESCRIPTION
Adds PDF Arranger (com.github.jeromerobert.pdfarranger) to the list of flatpaks to be installed.

PDF Arranger is a tool for merging, splitting, rotating, and rearranging PDF documents.

Reference: https://flathub.org/en/apps/com.github.jeromerobert.pdfarranger